### PR TITLE
fixing integers to enum in cache control

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -9,9 +9,9 @@ type AutopersistedBook @autopersist {
 
 # Cache control can be set at each field
 # ref: https://www.apollographql.com/docs/engine/caching.html
-type CachedBook @cacheControl(scope: PUBLIC, maxAge: 120) {
+type CachedBook @cacheControl(scope: PUBLIC, maxAge: SHORT) {
   id: ID!
-  name: String       @cacheControl(scope: PUBLIC, maxAge: 40)
+  name: String       @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
   authors: [String!] @cacheControl(scope: PRIVATE)
 }
 


### PR DESCRIPTION
There was a bug waiting to happen on maxAge of cacheControl in GraphQL. We decided to use enums instead of integers on maxAge.